### PR TITLE
API呼び出しを実装

### DIFF
--- a/lib/model/search_result_data.dart
+++ b/lib/model/search_result_data.dart
@@ -1,0 +1,68 @@
+/// freezedアノテーションを付けたクラスのフィールドに@JsonKeyを使用すると警告が出るためこのファイル上では無視する
+/// https://github.com/rrousselGit/freezed/issues/488
+// ignore_for_file: invalid_annotation_target
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part 'search_result_data.freezed.dart';
+part 'search_result_data.g.dart';
+
+///
+/// APIから取得した検索結果を保持しておくためのクラス
+///
+
+@freezed
+class SearchResultData with _$SearchResultData {
+  const SearchResultData._();
+
+  const factory SearchResultData({
+    @Default(0) @JsonKey(name: 'total_count') int totalCount,
+    @Default(false) @JsonKey(name: 'incomplete_results') bool incompleteResults,
+    @Default([]) @JsonKey(name: 'items') List<SearchResultItemData> items,
+  }) = _SearchResultData;
+
+  factory SearchResultData.fromJson(Map<String, dynamic> json) => _$SearchResultDataFromJson(json);
+}
+
+@freezed
+class SearchResultItemData with _$SearchResultItemData {
+  const SearchResultItemData._();
+
+  const factory SearchResultItemData({
+    // リポジトリ名
+    @Default('') @JsonKey(name: 'full_name') String repositoryName,
+
+    // オーナーの情報
+    @Default(Owner()) @JsonKey(name: 'owner') Owner owner,
+
+    // プロジェクト言語
+    @Default('') String language,
+
+    // Star 数
+    @Default(0) @JsonKey(name: 'stargazers_count') int starCount,
+
+    // Watcher 数
+    @Default(0) @JsonKey(name: 'watchers_count') int watchersCount,
+
+    // Fork 数
+    @Default(0) @JsonKey(name: 'forks_count') int forksCount,
+
+    // Issue 数
+    @Default(0) @JsonKey(name: 'open_issues_count') int issuesCount,
+  }) = _SearchResultItemData;
+
+  factory SearchResultItemData.fromJson(Map<String, dynamic> json) => _$SearchResultItemDataFromJson(json);
+}
+
+@freezed
+class Owner with _$Owner {
+  const Owner._();
+
+  const factory Owner({
+    // オーナーアイコン
+    @Default('') @JsonKey(name: 'avatar_url') String ownerIconUrl,
+  }) = _Owner;
+
+  factory Owner.fromJson(Map<String, dynamic> json) => _$OwnerFromJson(json);
+}

--- a/lib/model/search_result_data.freezed.dart
+++ b/lib/model/search_result_data.freezed.dart
@@ -1,0 +1,706 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'search_result_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+SearchResultData _$SearchResultDataFromJson(Map<String, dynamic> json) {
+  return _SearchResultData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SearchResultData {
+  @JsonKey(name: 'total_count')
+  int get totalCount => throw _privateConstructorUsedError;
+  @JsonKey(name: 'incomplete_results')
+  bool get incompleteResults => throw _privateConstructorUsedError;
+  @JsonKey(name: 'items')
+  List<SearchResultItemData> get items => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SearchResultDataCopyWith<SearchResultData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SearchResultDataCopyWith<$Res> {
+  factory $SearchResultDataCopyWith(
+          SearchResultData value, $Res Function(SearchResultData) then) =
+      _$SearchResultDataCopyWithImpl<$Res, SearchResultData>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total_count') int totalCount,
+      @JsonKey(name: 'incomplete_results') bool incompleteResults,
+      @JsonKey(name: 'items') List<SearchResultItemData> items});
+}
+
+/// @nodoc
+class _$SearchResultDataCopyWithImpl<$Res, $Val extends SearchResultData>
+    implements $SearchResultDataCopyWith<$Res> {
+  _$SearchResultDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? totalCount = null,
+    Object? incompleteResults = null,
+    Object? items = null,
+  }) {
+    return _then(_value.copyWith(
+      totalCount: null == totalCount
+          ? _value.totalCount
+          : totalCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      incompleteResults: null == incompleteResults
+          ? _value.incompleteResults
+          : incompleteResults // ignore: cast_nullable_to_non_nullable
+              as bool,
+      items: null == items
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<SearchResultItemData>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SearchResultDataImplCopyWith<$Res>
+    implements $SearchResultDataCopyWith<$Res> {
+  factory _$$SearchResultDataImplCopyWith(_$SearchResultDataImpl value,
+          $Res Function(_$SearchResultDataImpl) then) =
+      __$$SearchResultDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total_count') int totalCount,
+      @JsonKey(name: 'incomplete_results') bool incompleteResults,
+      @JsonKey(name: 'items') List<SearchResultItemData> items});
+}
+
+/// @nodoc
+class __$$SearchResultDataImplCopyWithImpl<$Res>
+    extends _$SearchResultDataCopyWithImpl<$Res, _$SearchResultDataImpl>
+    implements _$$SearchResultDataImplCopyWith<$Res> {
+  __$$SearchResultDataImplCopyWithImpl(_$SearchResultDataImpl _value,
+      $Res Function(_$SearchResultDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? totalCount = null,
+    Object? incompleteResults = null,
+    Object? items = null,
+  }) {
+    return _then(_$SearchResultDataImpl(
+      totalCount: null == totalCount
+          ? _value.totalCount
+          : totalCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      incompleteResults: null == incompleteResults
+          ? _value.incompleteResults
+          : incompleteResults // ignore: cast_nullable_to_non_nullable
+              as bool,
+      items: null == items
+          ? _value._items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<SearchResultItemData>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SearchResultDataImpl extends _SearchResultData
+    with DiagnosticableTreeMixin {
+  const _$SearchResultDataImpl(
+      {@JsonKey(name: 'total_count') this.totalCount = 0,
+      @JsonKey(name: 'incomplete_results') this.incompleteResults = false,
+      @JsonKey(name: 'items')
+      final List<SearchResultItemData> items = const []})
+      : _items = items,
+        super._();
+
+  factory _$SearchResultDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SearchResultDataImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'total_count')
+  final int totalCount;
+  @override
+  @JsonKey(name: 'incomplete_results')
+  final bool incompleteResults;
+  final List<SearchResultItemData> _items;
+  @override
+  @JsonKey(name: 'items')
+  List<SearchResultItemData> get items {
+    if (_items is EqualUnmodifiableListView) return _items;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_items);
+  }
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'SearchResultData(totalCount: $totalCount, incompleteResults: $incompleteResults, items: $items)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'SearchResultData'))
+      ..add(DiagnosticsProperty('totalCount', totalCount))
+      ..add(DiagnosticsProperty('incompleteResults', incompleteResults))
+      ..add(DiagnosticsProperty('items', items));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchResultDataImpl &&
+            (identical(other.totalCount, totalCount) ||
+                other.totalCount == totalCount) &&
+            (identical(other.incompleteResults, incompleteResults) ||
+                other.incompleteResults == incompleteResults) &&
+            const DeepCollectionEquality().equals(other._items, _items));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, totalCount, incompleteResults,
+      const DeepCollectionEquality().hash(_items));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchResultDataImplCopyWith<_$SearchResultDataImpl> get copyWith =>
+      __$$SearchResultDataImplCopyWithImpl<_$SearchResultDataImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SearchResultDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SearchResultData extends SearchResultData {
+  const factory _SearchResultData(
+          {@JsonKey(name: 'total_count') final int totalCount,
+          @JsonKey(name: 'incomplete_results') final bool incompleteResults,
+          @JsonKey(name: 'items') final List<SearchResultItemData> items}) =
+      _$SearchResultDataImpl;
+  const _SearchResultData._() : super._();
+
+  factory _SearchResultData.fromJson(Map<String, dynamic> json) =
+      _$SearchResultDataImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'total_count')
+  int get totalCount;
+  @override
+  @JsonKey(name: 'incomplete_results')
+  bool get incompleteResults;
+  @override
+  @JsonKey(name: 'items')
+  List<SearchResultItemData> get items;
+  @override
+  @JsonKey(ignore: true)
+  _$$SearchResultDataImplCopyWith<_$SearchResultDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+SearchResultItemData _$SearchResultItemDataFromJson(Map<String, dynamic> json) {
+  return _SearchResultItemData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SearchResultItemData {
+// リポジトリ名
+  @JsonKey(name: 'full_name')
+  String get repositoryName => throw _privateConstructorUsedError; // オーナーの情報
+  @JsonKey(name: 'owner')
+  Owner get owner => throw _privateConstructorUsedError; // プロジェクト言語
+  String get language => throw _privateConstructorUsedError; // Star 数
+  @JsonKey(name: 'stargazers_count')
+  int get starCount => throw _privateConstructorUsedError; // Watcher 数
+  @JsonKey(name: 'watchers_count')
+  int get watchersCount => throw _privateConstructorUsedError; // Fork 数
+  @JsonKey(name: 'forks_count')
+  int get forksCount => throw _privateConstructorUsedError; // Issue 数
+  @JsonKey(name: 'open_issues_count')
+  int get issuesCount => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SearchResultItemDataCopyWith<SearchResultItemData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SearchResultItemDataCopyWith<$Res> {
+  factory $SearchResultItemDataCopyWith(SearchResultItemData value,
+          $Res Function(SearchResultItemData) then) =
+      _$SearchResultItemDataCopyWithImpl<$Res, SearchResultItemData>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'full_name') String repositoryName,
+      @JsonKey(name: 'owner') Owner owner,
+      String language,
+      @JsonKey(name: 'stargazers_count') int starCount,
+      @JsonKey(name: 'watchers_count') int watchersCount,
+      @JsonKey(name: 'forks_count') int forksCount,
+      @JsonKey(name: 'open_issues_count') int issuesCount});
+
+  $OwnerCopyWith<$Res> get owner;
+}
+
+/// @nodoc
+class _$SearchResultItemDataCopyWithImpl<$Res,
+        $Val extends SearchResultItemData>
+    implements $SearchResultItemDataCopyWith<$Res> {
+  _$SearchResultItemDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? repositoryName = null,
+    Object? owner = null,
+    Object? language = null,
+    Object? starCount = null,
+    Object? watchersCount = null,
+    Object? forksCount = null,
+    Object? issuesCount = null,
+  }) {
+    return _then(_value.copyWith(
+      repositoryName: null == repositoryName
+          ? _value.repositoryName
+          : repositoryName // ignore: cast_nullable_to_non_nullable
+              as String,
+      owner: null == owner
+          ? _value.owner
+          : owner // ignore: cast_nullable_to_non_nullable
+              as Owner,
+      language: null == language
+          ? _value.language
+          : language // ignore: cast_nullable_to_non_nullable
+              as String,
+      starCount: null == starCount
+          ? _value.starCount
+          : starCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      watchersCount: null == watchersCount
+          ? _value.watchersCount
+          : watchersCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      forksCount: null == forksCount
+          ? _value.forksCount
+          : forksCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      issuesCount: null == issuesCount
+          ? _value.issuesCount
+          : issuesCount // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OwnerCopyWith<$Res> get owner {
+    return $OwnerCopyWith<$Res>(_value.owner, (value) {
+      return _then(_value.copyWith(owner: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SearchResultItemDataImplCopyWith<$Res>
+    implements $SearchResultItemDataCopyWith<$Res> {
+  factory _$$SearchResultItemDataImplCopyWith(_$SearchResultItemDataImpl value,
+          $Res Function(_$SearchResultItemDataImpl) then) =
+      __$$SearchResultItemDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'full_name') String repositoryName,
+      @JsonKey(name: 'owner') Owner owner,
+      String language,
+      @JsonKey(name: 'stargazers_count') int starCount,
+      @JsonKey(name: 'watchers_count') int watchersCount,
+      @JsonKey(name: 'forks_count') int forksCount,
+      @JsonKey(name: 'open_issues_count') int issuesCount});
+
+  @override
+  $OwnerCopyWith<$Res> get owner;
+}
+
+/// @nodoc
+class __$$SearchResultItemDataImplCopyWithImpl<$Res>
+    extends _$SearchResultItemDataCopyWithImpl<$Res, _$SearchResultItemDataImpl>
+    implements _$$SearchResultItemDataImplCopyWith<$Res> {
+  __$$SearchResultItemDataImplCopyWithImpl(_$SearchResultItemDataImpl _value,
+      $Res Function(_$SearchResultItemDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? repositoryName = null,
+    Object? owner = null,
+    Object? language = null,
+    Object? starCount = null,
+    Object? watchersCount = null,
+    Object? forksCount = null,
+    Object? issuesCount = null,
+  }) {
+    return _then(_$SearchResultItemDataImpl(
+      repositoryName: null == repositoryName
+          ? _value.repositoryName
+          : repositoryName // ignore: cast_nullable_to_non_nullable
+              as String,
+      owner: null == owner
+          ? _value.owner
+          : owner // ignore: cast_nullable_to_non_nullable
+              as Owner,
+      language: null == language
+          ? _value.language
+          : language // ignore: cast_nullable_to_non_nullable
+              as String,
+      starCount: null == starCount
+          ? _value.starCount
+          : starCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      watchersCount: null == watchersCount
+          ? _value.watchersCount
+          : watchersCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      forksCount: null == forksCount
+          ? _value.forksCount
+          : forksCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      issuesCount: null == issuesCount
+          ? _value.issuesCount
+          : issuesCount // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SearchResultItemDataImpl extends _SearchResultItemData
+    with DiagnosticableTreeMixin {
+  const _$SearchResultItemDataImpl(
+      {@JsonKey(name: 'full_name') this.repositoryName = '',
+      @JsonKey(name: 'owner') this.owner = const Owner(),
+      this.language = '',
+      @JsonKey(name: 'stargazers_count') this.starCount = 0,
+      @JsonKey(name: 'watchers_count') this.watchersCount = 0,
+      @JsonKey(name: 'forks_count') this.forksCount = 0,
+      @JsonKey(name: 'open_issues_count') this.issuesCount = 0})
+      : super._();
+
+  factory _$SearchResultItemDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SearchResultItemDataImplFromJson(json);
+
+// リポジトリ名
+  @override
+  @JsonKey(name: 'full_name')
+  final String repositoryName;
+// オーナーの情報
+  @override
+  @JsonKey(name: 'owner')
+  final Owner owner;
+// プロジェクト言語
+  @override
+  @JsonKey()
+  final String language;
+// Star 数
+  @override
+  @JsonKey(name: 'stargazers_count')
+  final int starCount;
+// Watcher 数
+  @override
+  @JsonKey(name: 'watchers_count')
+  final int watchersCount;
+// Fork 数
+  @override
+  @JsonKey(name: 'forks_count')
+  final int forksCount;
+// Issue 数
+  @override
+  @JsonKey(name: 'open_issues_count')
+  final int issuesCount;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'SearchResultItemData(repositoryName: $repositoryName, owner: $owner, language: $language, starCount: $starCount, watchersCount: $watchersCount, forksCount: $forksCount, issuesCount: $issuesCount)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'SearchResultItemData'))
+      ..add(DiagnosticsProperty('repositoryName', repositoryName))
+      ..add(DiagnosticsProperty('owner', owner))
+      ..add(DiagnosticsProperty('language', language))
+      ..add(DiagnosticsProperty('starCount', starCount))
+      ..add(DiagnosticsProperty('watchersCount', watchersCount))
+      ..add(DiagnosticsProperty('forksCount', forksCount))
+      ..add(DiagnosticsProperty('issuesCount', issuesCount));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchResultItemDataImpl &&
+            (identical(other.repositoryName, repositoryName) ||
+                other.repositoryName == repositoryName) &&
+            (identical(other.owner, owner) || other.owner == owner) &&
+            (identical(other.language, language) ||
+                other.language == language) &&
+            (identical(other.starCount, starCount) ||
+                other.starCount == starCount) &&
+            (identical(other.watchersCount, watchersCount) ||
+                other.watchersCount == watchersCount) &&
+            (identical(other.forksCount, forksCount) ||
+                other.forksCount == forksCount) &&
+            (identical(other.issuesCount, issuesCount) ||
+                other.issuesCount == issuesCount));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, repositoryName, owner, language,
+      starCount, watchersCount, forksCount, issuesCount);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchResultItemDataImplCopyWith<_$SearchResultItemDataImpl>
+      get copyWith =>
+          __$$SearchResultItemDataImplCopyWithImpl<_$SearchResultItemDataImpl>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SearchResultItemDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SearchResultItemData extends SearchResultItemData {
+  const factory _SearchResultItemData(
+          {@JsonKey(name: 'full_name') final String repositoryName,
+          @JsonKey(name: 'owner') final Owner owner,
+          final String language,
+          @JsonKey(name: 'stargazers_count') final int starCount,
+          @JsonKey(name: 'watchers_count') final int watchersCount,
+          @JsonKey(name: 'forks_count') final int forksCount,
+          @JsonKey(name: 'open_issues_count') final int issuesCount}) =
+      _$SearchResultItemDataImpl;
+  const _SearchResultItemData._() : super._();
+
+  factory _SearchResultItemData.fromJson(Map<String, dynamic> json) =
+      _$SearchResultItemDataImpl.fromJson;
+
+  @override // リポジトリ名
+  @JsonKey(name: 'full_name')
+  String get repositoryName;
+  @override // オーナーの情報
+  @JsonKey(name: 'owner')
+  Owner get owner;
+  @override // プロジェクト言語
+  String get language;
+  @override // Star 数
+  @JsonKey(name: 'stargazers_count')
+  int get starCount;
+  @override // Watcher 数
+  @JsonKey(name: 'watchers_count')
+  int get watchersCount;
+  @override // Fork 数
+  @JsonKey(name: 'forks_count')
+  int get forksCount;
+  @override // Issue 数
+  @JsonKey(name: 'open_issues_count')
+  int get issuesCount;
+  @override
+  @JsonKey(ignore: true)
+  _$$SearchResultItemDataImplCopyWith<_$SearchResultItemDataImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+Owner _$OwnerFromJson(Map<String, dynamic> json) {
+  return _Owner.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Owner {
+// オーナーアイコン
+  @JsonKey(name: 'avatar_url')
+  String get ownerIconUrl => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $OwnerCopyWith<Owner> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OwnerCopyWith<$Res> {
+  factory $OwnerCopyWith(Owner value, $Res Function(Owner) then) =
+      _$OwnerCopyWithImpl<$Res, Owner>;
+  @useResult
+  $Res call({@JsonKey(name: 'avatar_url') String ownerIconUrl});
+}
+
+/// @nodoc
+class _$OwnerCopyWithImpl<$Res, $Val extends Owner>
+    implements $OwnerCopyWith<$Res> {
+  _$OwnerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? ownerIconUrl = null,
+  }) {
+    return _then(_value.copyWith(
+      ownerIconUrl: null == ownerIconUrl
+          ? _value.ownerIconUrl
+          : ownerIconUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$OwnerImplCopyWith<$Res> implements $OwnerCopyWith<$Res> {
+  factory _$$OwnerImplCopyWith(
+          _$OwnerImpl value, $Res Function(_$OwnerImpl) then) =
+      __$$OwnerImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'avatar_url') String ownerIconUrl});
+}
+
+/// @nodoc
+class __$$OwnerImplCopyWithImpl<$Res>
+    extends _$OwnerCopyWithImpl<$Res, _$OwnerImpl>
+    implements _$$OwnerImplCopyWith<$Res> {
+  __$$OwnerImplCopyWithImpl(
+      _$OwnerImpl _value, $Res Function(_$OwnerImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? ownerIconUrl = null,
+  }) {
+    return _then(_$OwnerImpl(
+      ownerIconUrl: null == ownerIconUrl
+          ? _value.ownerIconUrl
+          : ownerIconUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$OwnerImpl extends _Owner with DiagnosticableTreeMixin {
+  const _$OwnerImpl({@JsonKey(name: 'avatar_url') this.ownerIconUrl = ''})
+      : super._();
+
+  factory _$OwnerImpl.fromJson(Map<String, dynamic> json) =>
+      _$$OwnerImplFromJson(json);
+
+// オーナーアイコン
+  @override
+  @JsonKey(name: 'avatar_url')
+  final String ownerIconUrl;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'Owner(ownerIconUrl: $ownerIconUrl)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'Owner'))
+      ..add(DiagnosticsProperty('ownerIconUrl', ownerIconUrl));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OwnerImpl &&
+            (identical(other.ownerIconUrl, ownerIconUrl) ||
+                other.ownerIconUrl == ownerIconUrl));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, ownerIconUrl);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OwnerImplCopyWith<_$OwnerImpl> get copyWith =>
+      __$$OwnerImplCopyWithImpl<_$OwnerImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$OwnerImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Owner extends Owner {
+  const factory _Owner(
+      {@JsonKey(name: 'avatar_url') final String ownerIconUrl}) = _$OwnerImpl;
+  const _Owner._() : super._();
+
+  factory _Owner.fromJson(Map<String, dynamic> json) = _$OwnerImpl.fromJson;
+
+  @override // オーナーアイコン
+  @JsonKey(name: 'avatar_url')
+  String get ownerIconUrl;
+  @override
+  @JsonKey(ignore: true)
+  _$$OwnerImplCopyWith<_$OwnerImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/search_result_data.g.dart
+++ b/lib/model/search_result_data.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_result_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SearchResultDataImpl _$$SearchResultDataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SearchResultDataImpl(
+      totalCount: json['total_count'] as int? ?? 0,
+      incompleteResults: json['incomplete_results'] as bool? ?? false,
+      items: (json['items'] as List<dynamic>?)
+              ?.map((e) =>
+                  SearchResultItemData.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$$SearchResultDataImplToJson(
+        _$SearchResultDataImpl instance) =>
+    <String, dynamic>{
+      'total_count': instance.totalCount,
+      'incomplete_results': instance.incompleteResults,
+      'items': instance.items,
+    };
+
+_$SearchResultItemDataImpl _$$SearchResultItemDataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SearchResultItemDataImpl(
+      repositoryName: json['full_name'] as String? ?? '',
+      owner: json['owner'] == null
+          ? const Owner()
+          : Owner.fromJson(json['owner'] as Map<String, dynamic>),
+      language: json['language'] as String? ?? '',
+      starCount: json['stargazers_count'] as int? ?? 0,
+      watchersCount: json['watchers_count'] as int? ?? 0,
+      forksCount: json['forks_count'] as int? ?? 0,
+      issuesCount: json['open_issues_count'] as int? ?? 0,
+    );
+
+Map<String, dynamic> _$$SearchResultItemDataImplToJson(
+        _$SearchResultItemDataImpl instance) =>
+    <String, dynamic>{
+      'full_name': instance.repositoryName,
+      'owner': instance.owner,
+      'language': instance.language,
+      'stargazers_count': instance.starCount,
+      'watchers_count': instance.watchersCount,
+      'forks_count': instance.forksCount,
+      'open_issues_count': instance.issuesCount,
+    };
+
+_$OwnerImpl _$$OwnerImplFromJson(Map<String, dynamic> json) => _$OwnerImpl(
+      ownerIconUrl: json['avatar_url'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$$OwnerImplToJson(_$OwnerImpl instance) =>
+    <String, dynamic>{
+      'avatar_url': instance.ownerIconUrl,
+    };

--- a/lib/repository/search_repository.dart
+++ b/lib/repository/search_repository.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:logger/logger.dart';
+import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
+
+class SearchGitHubRepository {
+  var logger = Logger();
+
+  Future<SearchResultData?> fetchSearchResult(String searchWord) async {
+    try {
+      final res = await http.get(Uri.parse('https://api.github.com/search/repositories?q=$searchWord'));
+      final statusCode = res.statusCode;
+      if (statusCode == 200) {
+        final body = jsonDecode(res.body);
+        final data = SearchResultData.fromJson(body);
+        return data;
+      } else {
+        logger.e('[SearchGitHubRepository.fetchSearchResult] API STATUS ERROR ', error: 'statusCode = $statusCode');
+      }
+    } catch (e) {
+      logger.e('[SearchGitHubRepository.fetchSearchResult] EXCEPTION ERROR ', error: e);
+    }
+
+    return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,90 +1,27 @@
 name: yumemi_github_search_repositories
 description: A new Flutter project.
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none' 
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
 version: 1.0.0+1
 
 environment:
   sdk: '>=3.1.5 <4.0.0'
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
-
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  json_serializable: ^6.7.1
+  freezed_annotation: ^2.4.1
+  http: ^1.1.0
+  logger: ^2.0.2+1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^2.0.0
+  freezed: ^2.4.5
+  build_runner: ^2.4.6
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/test/unit_test/search_result_data_convert_form_json_test.dart
+++ b/test/unit_test/search_result_data_convert_form_json_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
+
+///
+/// [SearchResultData]の.fromJson()が期待値通りの値を返すかのテスト
+///
+void main() {
+  test('Search result data convert form json', () {
+    for (final pattern in _searchResultTestPatterns) {
+      final result = SearchResultData.fromJson(pattern.testData);
+
+      expect(pattern.expect, result, reason: '${pattern.name} is FAILED');
+    }
+  });
+}
+
+final List<SearchResultDataTestPattern> _searchResultTestPatterns = [
+  // 1.testDataの各要素の並び順がSearchResultData内のデータの並び順とそろっている、itemsが2つ
+  SearchResultDataTestPattern(
+    name: '1.正常系(testDataの各要素の並び順がSearchResultData内のデータの並び順とそろっている)',
+    testData: _alignedData,
+    expect: const SearchResultData(
+      totalCount: 125,
+      incompleteResults: false,
+      items: [
+        SearchResultItemData(
+          repositoryName: 'testRepository1',
+          owner: Owner(ownerIconUrl: 'image.png'),
+          language: 'Dart',
+          starCount: 8,
+          watchersCount: 10,
+          forksCount: 15,
+          issuesCount: 20,
+        ),
+        SearchResultItemData(
+          repositoryName: 'testRepository2',
+          owner: Owner(ownerIconUrl: 'image.jpg'),
+          language: 'C#',
+          starCount: 15,
+          watchersCount: 21,
+          forksCount: 12,
+          issuesCount: 18,
+        ),
+      ],
+    ),
+  ),
+  // 2.itemsが1つ、testDataの各要素の並び順がSearchResultData内のデータの並び順と一致していない
+  SearchResultDataTestPattern(
+    name: '2.正常系(testDataの各要素の並び順がSearchResultData内のデータの並び順と一致していない)',
+    testData: _unalignedData,
+    expect: const SearchResultData(
+      totalCount: 35,
+      incompleteResults: true,
+      items: [
+        SearchResultItemData(
+          repositoryName: 'testRepository3',
+          owner: Owner(ownerIconUrl: 'image.gif'),
+          language: 'Java',
+          starCount: 16,
+          watchersCount: 40,
+          forksCount: 32,
+          issuesCount: 56,
+        ),
+      ],
+    ),
+  ),
+  // 3.testDataの中身が空
+  const SearchResultDataTestPattern(
+    name: '3.異常系(testDataの中身が空)',
+    testData: {},
+    expect: SearchResultData(),
+  ),
+];
+
+/// テストするデータとその期待値をまとめておくクラス
+class SearchResultDataTestPattern {
+  const SearchResultDataTestPattern({
+    required this.name,
+    required this.testData,
+    required this.expect,
+  });
+
+  /// テストの概要を表す名称
+  final String name;
+
+  /// テストデータ
+  final Map<String, dynamic> testData;
+
+  ///
+  final SearchResultData expect;
+}
+
+/// ------------------------------
+/// 以降はテスト用のダミーデータ
+/// ------------------------------
+
+Map<String, dynamic> _alignedData = {
+  'total_count': 125,
+  'incomplete_results': false,
+  'items': [
+    _searchResultItemTestData1,
+    _searchResultItemTestData2,
+  ],
+};
+
+Map<String, dynamic> _unalignedData = {
+  'items': [
+    _searchResultItemTestData3,
+  ],
+  'total_count': 35,
+  'incomplete_results': true,
+};
+
+Map<String, dynamic> _searchResultItemTestData1 = {
+  'full_name': 'testRepository1',
+  'owner': _ownerTestData1,
+  'language': 'Dart',
+  'stargazers_count': 8,
+  'watchers_count': 10,
+  'forks_count': 15,
+  'open_issues_count': 20,
+};
+
+Map<String, dynamic> _ownerTestData1 = {'avatar_url': 'image.png'};
+
+Map<String, dynamic> _searchResultItemTestData2 = {
+  'full_name': 'testRepository2',
+  'owner': _ownerTestData2,
+  'language': 'C#',
+  'stargazers_count': 15,
+  'watchers_count': 21,
+  'forks_count': 12,
+  'open_issues_count': 18,
+};
+
+Map<String, dynamic> _ownerTestData2 = {'avatar_url': 'image.jpg'};
+
+Map<String, dynamic> _searchResultItemTestData3 = {
+  'watchers_count': 40,
+  'language': 'Java',
+  'open_issues_count': 56,
+  'stargazers_count': 16,
+  'full_name': 'testRepository3',
+  'forks_count': 32,
+  'owner': _ownerTestData3,
+};
+
+Map<String, dynamic> _ownerTestData3 = {'avatar_url': 'image.gif'};


### PR DESCRIPTION
# 修正内容
## ①API呼び出し処理のためのライブラリを追加
* 主なものは以下
    * http
    * fleezed

## ②APIから取得したデータを保持させるためのmodelを作成
APIから取得したデータを保持させておく`SearchResultData`を作成
今後riverpodで使用すること、また、jsonからのコンバートを行うためにfreezedしている

## ③実際にAPI呼び出しを行うrepositoryを追加
APIリクエストを行う`SearchGitHubRepository`を実装
ここでAPIから取得したデータを②で作成したmodelの`SearchResultData`に落とし込んで呼び出し元に返却する

## ④`SearchResultData`の.fromJson()のテストを作成
APIから取得したJsonを`SearchResultData`に変換する処理に対しunitTestを作成