### PR TITLE
APIClientの追加

### DIFF
--- a/lib/api/search_resurt_api_client.dart
+++ b/lib/api/search_resurt_api_client.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// githubAPI[Search repositories]へのAPIClient
+class SearchResultApiClient {
+  /// API呼び出しを行う
+  Future<Map<String, dynamic>> get(String searchWord) async {
+    final res = await http.get(Uri.parse('https://api.github.com/search/repositories?q=$searchWord'));
+    final statusCode = res.statusCode;
+    if (statusCode == 200) {
+      return jsonDecode(res.body);
+    } else {
+      throw Exception('[SearchGitHubRepository.fetchSearchResult] API STATUS ERROR statusCode = $statusCode');
+    }
+  }
+}

--- a/lib/repository/search_repository.dart
+++ b/lib/repository/search_repository.dart
@@ -1,27 +1,18 @@
-import 'dart:convert';
-
-import 'package:http/http.dart' as http;
 import 'package:logger/logger.dart';
+import 'package:yumemi_github_search_repositories/api/search_resurt_api_client.dart';
 import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
 
 class SearchGitHubRepository {
+  final _searchResultApiClient = SearchResultApiClient();
   var logger = Logger();
 
   Future<SearchResultData?> fetchSearchResult(String searchWord) async {
     try {
-      final res = await http.get(Uri.parse('https://api.github.com/search/repositories?q=$searchWord'));
-      final statusCode = res.statusCode;
-      if (statusCode == 200) {
-        final body = jsonDecode(res.body);
-        final data = SearchResultData.fromJson(body);
-        return data;
-      } else {
-        logger.e('[SearchGitHubRepository.fetchSearchResult] API STATUS ERROR ', error: 'statusCode = $statusCode');
-      }
-    } catch (e) {
-      logger.e('[SearchGitHubRepository.fetchSearchResult] EXCEPTION ERROR ', error: e);
+      final json = await _searchResultApiClient.get(searchWord);
+      return SearchResultData.fromJson(json);
+    } catch (e, stacktrace) {
+      logger.e('[SearchGitHubRepository.fetchSearchResult] EXCEPTION ERROR ', error: e, stackTrace: stacktrace);
     }
-
     return null;
   }
 }


### PR DESCRIPTION
# 修正内容
repositoryから直接APIを呼んでしまっていたため、呼び出し処理を行うAPIClientを追加

repositoryではAPIClientから取得したMapを`SearchResultData`に変換して返す