### PR TITLE
ViewModeのProviderを実装

### DIFF
--- a/lib/api/search_resurt_api_client.dart
+++ b/lib/api/search_resurt_api_client.dart
@@ -4,8 +4,8 @@ import 'package:http/http.dart' as http;
 /// githubAPI[Search repositories]へのAPIClient
 class SearchResultApiClient {
   /// API呼び出しを行う
-  Future<Map<String, dynamic>> get(String searchWord) async {
-    final res = await http.get(Uri.parse('https://api.github.com/search/repositories?q=$searchWord'));
+  Future<Map<String, dynamic>> get(String searchWord, int page) async {
+    final res = await http.get(Uri.parse('https://api.github.com/search/repositories?q=$searchWord&page=$page'));
     final statusCode = res.statusCode;
     if (statusCode == 200) {
       return jsonDecode(res.body);

--- a/lib/repository/search_repository.dart
+++ b/lib/repository/search_repository.dart
@@ -6,9 +6,9 @@ class SearchGitHubRepository {
   final _searchResultApiClient = SearchResultApiClient();
   var logger = Logger();
 
-  Future<SearchResultData?> fetchSearchResult(String searchWord) async {
+  Future<SearchResultData?> fetchSearchResult(String searchWord, int page) async {
     try {
-      final json = await _searchResultApiClient.get(searchWord);
+      final json = await _searchResultApiClient.get(searchWord, page);
       return SearchResultData.fromJson(json);
     } catch (e, stacktrace) {
       logger.e('[SearchGitHubRepository.fetchSearchResult] EXCEPTION ERROR ', error: e, stackTrace: stacktrace);

--- a/lib/view_model/search_result.dart
+++ b/lib/view_model/search_result.dart
@@ -1,0 +1,52 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
+import 'package:yumemi_github_search_repositories/repository/search_repository.dart';
+
+part 'search_result.g.dart';
+
+@riverpod
+class SearchResult extends _$SearchResult {
+  @override
+  Future<SearchResultData> build() async => const SearchResultData();
+
+  final _repo = SearchGitHubRepository();
+  late String _searchWord;
+  late int _page;
+
+  /// データ取得（1ページ目）
+  Future<void> getData(String searchWord) async {
+    _searchWord = searchWord;
+    _page = 1;
+    state = const AsyncLoading();
+
+    if (searchWord.isEmpty) {
+      // 検索ワードが空の場合はリクエストはせずstateを[SearchResultData]の初期値に更新
+      state = const AsyncData(SearchResultData());
+    } else {
+      try {
+        final res = await _repo.fetchSearchResult(_searchWord, _page);
+        if (res != null) {
+          state = AsyncData(res);
+        }
+      } catch (e, stack) {
+        state = AsyncError(e, stack);
+      }
+    }
+  }
+
+  /// データ取得（追加読み込み）
+  Future<void> getMoreData() async {
+    _page += 1;
+    state = const AsyncLoading();
+
+    try {
+      final res = await _repo.fetchSearchResult(_searchWord, _page);
+      if (res != null) {
+        final List<SearchResultItemData> upDatedItemList = [...state.value?.items ?? [], ...res.items];
+        state = AsyncData(res.copyWith(items: upDatedItemList));
+      }
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+    }
+  }
+}

--- a/lib/view_model/search_result.g.dart
+++ b/lib/view_model/search_result.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_result.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$searchResultHash() => r'c4656903cf9a0cf257eb0973ef8b303630a71107';
+
+/// See also [SearchResult].
+@ProviderFor(SearchResult)
+final searchResultProvider =
+    AutoDisposeAsyncNotifierProvider<SearchResult, SearchResultData>.internal(
+  SearchResult.new,
+  name: r'searchResultProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$searchResultHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$SearchResult = AutoDisposeAsyncNotifier<SearchResultData>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   freezed_annotation: ^2.4.1
   http: ^1.1.0
   logger: ^2.0.2+1
+  flutter_riverpod: ^2.4.5
+  riverpod_annotation: ^2.3.0
 
 dev_dependencies:
   flutter_test:
@@ -22,6 +24,8 @@ dev_dependencies:
   flutter_lints: ^2.0.0
   freezed: ^2.4.5
   build_runner: ^2.4.6
+  riverpod_generator: ^2.3.5
+  riverpod_lint: ^2.3.3
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
# 修正内容

## ①検索時にページを指定できるよう修正
検索時のページ指定ができない作りになってしまっていたため、指定できるようにrepository / ApiClientを修正
これから追加するProviderからページ指定でのリクエストを行えるようにしておく

## ②riverpodのライブラリを追加
ViewModelにはriverpodを使用するためライブラリを追加
Providerは自動生成できるように`riverpod_generator`も追加

## ③Providerの追加
`SearchResult`にriverpodアノテーションを付け、Providerを自動生成

`SearchResult`では`getData()`（1回目の検索実行）と`getMoreData()`（追加読み込み）が行えるようメソッドを準備