### PR TITLE
詳細画面の実装

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,5 +3,11 @@
   "textFieldHintText": "Search Word Hear",
   "totalCountTitle": "count",
   "failedToRetrieveDataError": "Failed To Retrieve Data",
-  "moreButtonText": "more"
+  "moreButtonText": "more",
+  "detailPageTitle": "Detailed information",
+  "language": "Language",
+  "star": "Star",
+  "watcher": "Watcher",
+  "fork": "Fork",
+  "issue": "Issue"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3,5 +3,11 @@
   "textFieldHintText": "検索ワードを入力してください",
   "totalCountTitle": "件数",
   "failedToRetrieveDataError": "データの取得に失敗しました",
-  "moreButtonText": "さらに表示する"
+  "moreButtonText": "さらに表示する",
+  "detailPageTitle": "詳細情報",
+  "language": "言語",
+  "star": "スター",
+  "watcher": "ウォッチャー",
+  "fork": "フォーク",
+  "issue": "イシュー"
 }

--- a/lib/model/page/page_definition.dart
+++ b/lib/model/page/page_definition.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_github_search_repositories/view/detail_page.dart';
+import 'package:yumemi_github_search_repositories/view/search_page.dart';
+
+///
+/// 画面の定義
+///
+
+enum PageDefinition {
+  searchPage,
+  detailPage,
+}
+
+// MaterialAppで使用する画面のroute
+Map<String, Widget Function(BuildContext)> routes = {
+  PageDefinition.searchPage.name: (context) => const SearchPage(),
+  PageDefinition.detailPage.name: (context) => const DetailPage(),
+};

--- a/lib/view/detail_page.dart
+++ b/lib/view/detail_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class DetailPage extends StatelessWidget {
+  const DetailPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final data = ModalRoute.of(context)?.settings.arguments;
+
+    if (data != null && data is SearchResultItemData) {
+      return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          title: Text(AppLocalizations.of(context)!.detailPageTitle),
+        ),
+        body: _buildBody(context, data),
+      );
+    } else {
+      return const SizedBox.shrink();
+    }
+  }
+
+  Widget _buildBody(BuildContext context, SearchResultItemData data) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        child: Column(
+          children: [
+            // オーナーアイコン
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Container(
+                alignment: Alignment.center,
+                width: 140,
+                height: 140,
+                decoration: BoxDecoration(
+                  color: Colors.grey[70],
+                  borderRadius: BorderRadius.circular(100),
+                  image: DecorationImage(
+                    fit: BoxFit.fitWidth,
+                    image: NetworkImage(data.owner.ownerIconUrl),
+                  ),
+                ),
+              ),
+            ),
+            Text(data.repositoryName, style: const TextStyle(fontSize: 26, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 24),
+            // 区切り線
+            Container(height: 1, color: Colors.grey),
+            const SizedBox(height: 24),
+            // プロジェクト言語
+            _buildRepositoryDataItem(context, Icons.language, AppLocalizations.of(context)!.language, data.language),
+            // Star 数
+            _buildRepositoryDataItem(context, Icons.star, AppLocalizations.of(context)!.star, data.starCount.toString()),
+            // Watcher 数
+            _buildRepositoryDataItem(context, Icons.remove_red_eye, AppLocalizations.of(context)!.watcher, data.watchersCount.toString()),
+            // Fork 数
+            _buildRepositoryDataItem(context, Icons.fork_left, AppLocalizations.of(context)!.fork, data.forksCount.toString()),
+            // Issue 数
+            _buildRepositoryDataItem(context, Icons.warning, AppLocalizations.of(context)!.issue, data.issuesCount.toString()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 「プロジェクト言語」や「starの数」などを表示するアイテム
+  Widget _buildRepositoryDataItem(BuildContext context, IconData icon, String title, String data) {
+    final text = data.isNotEmpty ? data : '-';
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 14),
+      child: Container(
+        height: 46,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.secondaryContainer,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Row(
+          children: [
+            const SizedBox(width: 15),
+            Icon(icon, size: 20),
+            const SizedBox(width: 10),
+            Text(title, style: const TextStyle(fontSize: 18)),
+            const Spacer(),
+            Text(text, style: const TextStyle(fontSize: 18)),
+            const SizedBox(width: 20)
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/search_page.dart
+++ b/lib/view/search_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_github_search_repositories/model/page/page_definition.dart';
 import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
 import 'package:yumemi_github_search_repositories/view_model/search_result.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -154,7 +155,7 @@ class SearchPage extends ConsumerWidget {
       title: Text(data.repositoryName),
       subtitle: Text(language, style: const TextStyle(color: Colors.grey)),
       trailing: const Icon(Icons.navigate_next),
-      onTap: () => null, // 詳細画面は別コミットで実装する
+      onTap: () => Navigator.of(context).pushNamed(PageDefinition.detailPage.name, arguments: data),
     );
   }
 }


### PR DESCRIPTION
# 修正内容
## 詳細画面の実装
検索結果画面のアイテムをタップで遷移できる、リポジトリの詳細情報を表示する画面を実装

検索結果画面からの遷移時にargumentでリポジトリのデータを受け取り、それを表示するだけの画面
表示するのは以下の項目
* オーナーのアイコン
* リポジトリ名
* プロジェクト言語
* スター数
* ウォッチャー数
* フォーク数
* イシュー数