### PR TITLE
ライトモード/ダークモードの切り替えを実装

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9,5 +9,8 @@
   "star": "Star",
   "watcher": "Watcher",
   "fork": "Fork",
-  "issue": "Issue"
+  "issue": "Issue",
+  "themeModeSystem": "Follow system settings",
+  "themeModLight": "Light mode",
+  "themeModeDark": "Dark mode"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -9,5 +9,8 @@
   "star": "スター",
   "watcher": "ウォッチャー",
   "fork": "フォーク",
-  "issue": "イシュー"
+  "issue": "イシュー",
+  "themeModeSystem": "システム設定に従う",
+  "themeModLight": "ライトモード",
+  "themeModeDark": "ダークモード"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,16 +4,19 @@ import 'package:yumemi_github_search_repositories/model/page/page_definition.dar
 import 'package:yumemi_github_search_repositories/view/search_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:yumemi_github_search_repositories/view_model/theme_mode.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeModeStateProvider);
+
     return MaterialApp(
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -25,10 +28,9 @@ class MyApp extends StatelessWidget {
         Locale('en', ''), // English, no country code
         Locale('ja', ''), // Japanese, no country code
       ],
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode: themeMode,
       home: const SearchPage(),
       routes: routes,
     );

--- a/lib/view/detail_page.dart
+++ b/lib/view/detail_page.dart
@@ -12,7 +12,6 @@ class DetailPage extends StatelessWidget {
     if (data != null && data is SearchResultItemData) {
       return Scaffold(
         appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
           title: Text(AppLocalizations.of(context)!.detailPageTitle),
         ),
         body: _buildBody(context, data),
@@ -71,12 +70,8 @@ class DetailPage extends StatelessWidget {
     final text = data.isNotEmpty ? data : '-';
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 14),
-      child: Container(
+      child: SizedBox(
         height: 46,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.secondaryContainer,
-          borderRadius: BorderRadius.circular(10),
-        ),
         child: Row(
           children: [
             const SizedBox(width: 15),

--- a/lib/view/search_page.dart
+++ b/lib/view/search_page.dart
@@ -4,6 +4,7 @@ import 'package:yumemi_github_search_repositories/model/page/page_definition.dar
 import 'package:yumemi_github_search_repositories/model/search_result_data.dart';
 import 'package:yumemi_github_search_repositories/view_model/search_result.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:yumemi_github_search_repositories/view_model/theme_mode.dart';
 
 ///
 /// 検索画面のUI
@@ -16,10 +17,39 @@ class SearchPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(AppLocalizations.of(context)!.searchPageTitle),
+        actions: [_buildChangeThemeModeMenu(ref)],
       ),
       body: _buildSearchBarAndResult(context, ref),
+    );
+  }
+
+  /// テーマモードを変更するメニューを表示するアイコン
+  Widget _buildChangeThemeModeMenu(WidgetRef ref) {
+    final themeMode = ref.watch(themeModeStateProvider.notifier);
+
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: PopupMenuButton<ThemeMode>(
+        icon: const Icon(Icons.settings_brightness),
+        // themeMode.state に選択された 外観モード をセットする
+        onSelected: (ThemeMode selectedThemeMode) => themeMode.update(selectedThemeMode),
+
+        itemBuilder: (context) => <PopupMenuEntry<ThemeMode>>[
+          PopupMenuItem(
+            value: ThemeMode.system,
+            child: Text(AppLocalizations.of(context)!.themeModeSystem),
+          ),
+          PopupMenuItem(
+            value: ThemeMode.light,
+            child: Text(AppLocalizations.of(context)!.themeModLight),
+          ),
+          PopupMenuItem(
+            value: ThemeMode.dark,
+            child: Text(AppLocalizations.of(context)!.themeModeDark),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/view_model/theme_mode.dart
+++ b/lib/view_model/theme_mode.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'theme_mode.g.dart';
+
+///
+/// テーマモード（ダークモード/ライトモード）の状態を持つクラス
+///
+
+@riverpod
+class ThemeModeState extends _$ThemeModeState {
+  @override
+  ThemeMode build() => ThemeMode.system;
+
+  /// テーマモードを更新
+  void update(ThemeMode mode) => state = mode;
+}

--- a/lib/view_model/theme_mode.g.dart
+++ b/lib/view_model/theme_mode.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theme_mode.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$themeModeStateHash() => r'bd6f49190987d8f4ad523f6470ee3cbe85046fc2';
+
+/// See also [ThemeModeState].
+@ProviderFor(ThemeModeState)
+final themeModeStateProvider =
+    AutoDisposeNotifierProvider<ThemeModeState, ThemeMode>.internal(
+  ThemeModeState.new,
+  name: r'themeModeStateProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$themeModeStateHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ThemeModeState = AutoDisposeNotifier<ThemeMode>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member


### PR DESCRIPTION
# 修正内容
## ①ThemeMode用のプロバイダーを追加
アプリのThemeModeの状態を管理するプロバイダー`ThemeModeState `を追加

## ②ThemeModeの切り替えを実装
プロバイダー`ThemeModeState`の状態をUI側で監視して、変更があればそれを反映させるよう処理を追加

また、モードを切り替えることで詳細画面のリポジトリ情報（プロジェクト言語やスターの数）のUIが見づらくなってしまったため見た目を修正

## ライトモード/ダークモードの切り替え
https://github.com/ondrkishi/yumemi_github_search_repositories/assets/93812971/5b731416-78e9-4844-988a-59f6d6a2b820

