### PR TITLE
providerでもAPIエラーを受け取れるよう修正

### DIFF
--- a/lib/api/search_resurt_api_client.dart
+++ b/lib/api/search_resurt_api_client.dart
@@ -10,6 +10,7 @@ class SearchResultApiClient {
     if (statusCode == 200) {
       return jsonDecode(res.body);
     } else {
+      // statusCode=200以外であれば例外をthrowする
       throw Exception('[SearchGitHubRepository.fetchSearchResult] API STATUS ERROR statusCode = $statusCode');
     }
   }

--- a/lib/repository/search_repository.dart
+++ b/lib/repository/search_repository.dart
@@ -6,13 +6,14 @@ class SearchGitHubRepository {
   final _searchResultApiClient = SearchResultApiClient();
   var logger = Logger();
 
-  Future<SearchResultData?> fetchSearchResult(String searchWord, int page) async {
+  /// APIから取得したjsonデータをSearchResultDataにして返す
+  Future<SearchResultData> fetchSearchResult(String searchWord, int page) async {
     try {
       final json = await _searchResultApiClient.get(searchWord, page);
       return SearchResultData.fromJson(json);
     } catch (e, stacktrace) {
       logger.e('[SearchGitHubRepository.fetchSearchResult] EXCEPTION ERROR ', error: e, stackTrace: stacktrace);
+      throw Exception('[SearchGitHubRepository.fetchSearchResult] EXCEPTION ERROR e = $e');
     }
-    return null;
   }
 }

--- a/lib/view_model/search_result.dart
+++ b/lib/view_model/search_result.dart
@@ -25,9 +25,7 @@ class SearchResult extends _$SearchResult {
     } else {
       try {
         final res = await _repo.fetchSearchResult(_searchWord, _page);
-        if (res != null) {
-          state = AsyncData(res);
-        }
+        state = AsyncData(res);
       } catch (e, stack) {
         state = AsyncError(e, stack);
       }
@@ -41,10 +39,8 @@ class SearchResult extends _$SearchResult {
 
     try {
       final res = await _repo.fetchSearchResult(_searchWord, _page);
-      if (res != null) {
-        final List<SearchResultItemData> upDatedItemList = [...state.value?.items ?? [], ...res.items];
-        state = AsyncData(res.copyWith(items: upDatedItemList));
-      }
+      final List<SearchResultItemData> upDatedItemList = [...state.value?.items ?? [], ...res.items];
+      state = AsyncData(res.copyWith(items: upDatedItemList));
     } catch (e, stack) {
       state = AsyncError(e, stack);
     }


### PR DESCRIPTION
# 修正内容
 repositoryでAPIエラーをつぶしておりproviderまで
エラーが届いていなかったため、repozitoryで例外をthrowするよう修正

providerでエラーをcatchした場合はstateを`AsyncError(e, stack);`に更新してUI側にエラーを表示する